### PR TITLE
Removing comma from last item in dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "minimist": "^1.2.0",
-    "request": "^2.69.0",
+    "request": "^2.69.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.6",


### PR DESCRIPTION
`npm install` was failing due to comma in dependencies list. Removed it so package.json is now valid JSON again.